### PR TITLE
Fix typo in prompt maker

### DIFF
--- a/promzard.js
+++ b/promzard.js
@@ -121,7 +121,7 @@ PromZard.prototype.makePrompt = function () {
       else if (a && typeof a === 'object') {
         p = a.prompt || p
         d = a.default || d
-        t = a.tranform || t
+        t = a.transform || t
       }
     }
 


### PR DESCRIPTION
Why isn't my transform function working?! Oh, because it's not a tranform function. Hee hee!
