### PR TITLE
Add encoding param to readFileSync to return String for .split() instead of Buffer

### DIFF
--- a/example/npm-init/init-input.js
+++ b/example/npm-init/init-input.js
@@ -156,7 +156,7 @@ module.exports = {
   })(),
 
   "repository" : (function () {
-    try { var gconf = fs.readFileSync('.git/config') }
+    try { var gconf = fs.readFileSync('.git/config','utf8') }
     catch (e) { gconf = null }
     if (gconf) {
       gconf = gconf.split(/\r?\n/)


### PR DESCRIPTION
Kept getting ".split is not a function" errors. 

![image](https://cloud.githubusercontent.com/assets/11944012/13510665/9cf7e454-e15f-11e5-84ac-bb9b30059c31.png)

Fixed by adding 'utf8' as second param to fs.readFileSync('.git/config') on line 159 so that readFileSync returns a String instead of a Buffer (as it does by default).

