### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
-language: node_js
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'
-before_install:
-  - npm install -g npm@latest


### PR DESCRIPTION
- Do not install latest `npm` as that is incompatible with the old Node.js versions used in the CI tests
- Do not test on Node.js 0.8 as `tap@^1.2.0` does not support that anymore