### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/promzard.js
+++ b/promzard.js
@@ -171,7 +171,7 @@ PromZard.prototype.walk = function (o, cb) {
       } else if (v &&
                  typeof v === 'string' &&
                  v.indexOf(this.unique) === 0) {
-        var n = +v.substr(this.unique.length + 1)
+        var n = +v.slice(this.unique.length + 1)
         var prompt = this.prompts[n]
         if (isNaN(n) || !prompt)
           continue


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.